### PR TITLE
gmilk -a(--all)時にエラーになる問題を修正

### DIFF
--- a/lib/milkode/grep/cli_grep.rb
+++ b/lib/milkode/grep/cli_grep.rb
@@ -113,7 +113,7 @@ EOF
           cdstk = Cdstk.new(stdout, Dbdir.select_dbdir)
 
           if (my_option[:all])
-            cdstk.update_all
+            cdstk.update_all(my_option)
           elsif (my_option[:packages].empty?)
             cdstk.update_for_grep(package_root_dir(File.expand_path(".")))
           else


### PR DESCRIPTION
gmilkを-aオプション付きで実行した際に、lib/milkode/grep/cli_grep.rbの116行目で「`update_all': wrong number of arguments (0 for 1) (ArgumentError)」となるのを修正
