### PR TITLE
Support Travis CI

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,9 @@
+notifications:
+  recipients:
+    - kou@clear-code.com
+    - ongaeshi0621@gmail.com
+rvm:
+  - 1.8.7
+  - 1.9.3
+before_install:
+  - curl https://raw.github.com/groonga/groonga/master/data/travis/setup.sh | sh


### PR DESCRIPTION
We need additional works to use Travis CI.

From http://about.travis-ci.org/docs/user/getting-started/

  Step one: Sign in
  Step two: Activate GitHub Service Hook
  Step three: Add .travis.yml file to your repository

This change does only the Step three. We need to do Step one and Step
two.
