### PR TITLE
Support removing by path

### DIFF
--- a/lib/milkode/cdstk/cdstk.rb
+++ b/lib/milkode/cdstk/cdstk.rb
@@ -332,7 +332,7 @@ module Milkode
           print_result do
             db_open
             args.each do |name|
-              package = @yaml.find_name(name)
+              package = @yaml.find_name(name) || @yaml.find_dir(name)
               if (package)
                 remove_dir(package.directory)                
               else

--- a/lib/milkode/cli.rb
+++ b/lib/milkode/cli.rb
@@ -51,7 +51,7 @@ EOF
       cdstk.update(args, options)
     end
 
-    desc "remove keyword1 [keyword2 ...]", "Remove package"
+    desc "remove keyword_or_path1 [keyword_or_path2 ...]", "Remove package"
     option :all, :type => :boolean, :desc => 'Remove all.'
     option :force, :type => :boolean, :aliases => '-f', :desc => 'Force remove.'
     option :verbose, :type => :boolean, :aliases => '-v', :desc => 'Be verbose.'


### PR DESCRIPTION
If `milk remove PATH` works, [gem-milkode](https://rubygems.org/gems/gem-milkode) is very happy.

gem-milkode is a RubyGems plugin that add installed gems to Milkode index and remove uninstalled gems automatically. If `milk remove PATH` works, gem-milkode can specify remove target by path.
