### PR TITLE
[cdweb] milkode.js: keep query text selected after searching

### DIFF
--- a/lib/milkode/cdweb/public/js/milkode.js
+++ b/lib/milkode/cdweb/public/js/milkode.js
@@ -90,6 +90,8 @@ $(document).ready(function(){
     return false;
   });
 
+  $('#query').select();
+
   $('#query').click(function(){
     $(this).select();
   });


### PR DESCRIPTION
入力したキーワードが検索後に選択されている状態のままにするパッチです。

これによって検索した結果がマッチしなかったり、別のキーワードで再検索したいときにデフォルトで選択されているとキーワードの訂正がしやすくなるので嬉しいです。
# 39は検索した結果表示された内容をコピペ->フォームをクリック->テキストが選択状態になるのでそのまま貼り付けできて嬉しいというもので、今回のは検索後にそのまま再検索を繰り返す場合を想定しています。
