### PR TITLE
[cdweb][bug] milkode.js: suppress select() call for query text by tag ju...

### DIFF
--- a/lib/milkode/cdweb/public/js/milkode.js
+++ b/lib/milkode/cdweb/public/js/milkode.js
@@ -90,7 +90,9 @@ $(document).ready(function(){
     return false;
   });
 
-  $('#query').select();
+  if (!(/.+#n\d+$/.test(document.URL))) {
+    $("#query").select();
+  }
 
   $('#query').click(function(){
     $(this).select();


### PR DESCRIPTION
...mp

'tag jump' does not work well by forcing select() call.
This bug is introduced at https://github.com/ongaeshi/milkode/pull/40. Sorry...
# 40をマージしていただいたんですが、ソースコードの該当行にジャンプするときに、

必ずselec()してしまうとフォーカスがそっちにもってかれてしまうのでよろしくないことに気が付きました。

このパッチはURLの末尾が#nXXXだとselect()を適用しないようにします。
