### PR TITLE
Missing meta tag for "shortcut icon" at search result page.

### DIFF
--- a/lib/milkode/cdweb/views/layout.haml
+++ b/lib/milkode/cdweb/views/layout.haml
@@ -4,6 +4,7 @@
   %head
     %meta(charset='utf-8')
     %title= [@title, @setting.home_title].compact.join(' - ')
+    %link(rel="shortcut icon" href="#{@setting.favicon}")
     %link(rel="stylesheet" href="/css/bootstrap.min.css"  type="text/css" media="all")
     %link(rel="stylesheet" href="/css/bootstrap-responsive.min.css"  type="text/css" media="all")
     %link(rel="stylesheet" href="/css/milkode.css"  type="text/css" media="all")


### PR DESCRIPTION
Some web browser like GoogleChrome is trying to get /favicon.ico on every access.
So, I have add a meta tag for `layout.haml` as `index.haml` does.
