### PR TITLE
Add escape to query from gomilk

### DIFF
--- a/lib/milkode/cdweb/lib/command.rb
+++ b/lib/milkode/cdweb/lib/command.rb
@@ -138,7 +138,7 @@ module Milkode
     documents = Database.instance.documents
     grn = documents.table
 
-    query = params[:query]
+    query = %Q|"#{params[:query]}"|
 
     unless params[:all]
       begin


### PR DESCRIPTION
gomilk経由で検索する際に、検索文字列に"::"が含まれていると、以下のようなエラーが発生してしまいます。

``` ruby
Groonga::InvalidArgument - invalid argument: column lookup failed: [#<Groonga::Expression noname($1:null){}>, ["ActiveRecord::FixtureSet.context_class", {:syntax=>:query, :allow_pragma=>nil, :allow_column=>nil, :allow_update=>nil, :allow_leading_not=>nil, :default_column=>"content"}]]
expr.c:6018: get_word_():
```

ダブルコーテーションでqueryを括る事で、該当のエラーが出ない事確認出来ました。　

お手隙の際に、ご確認をお願い致します。
