### PR TITLE
Use Open3.pipeline to avoid shell.

### DIFF
--- a/lib/milkode/grep/cli_grep.rb
+++ b/lib/milkode/grep/cli_grep.rb
@@ -8,6 +8,8 @@ require 'milkode/common/util'
 require 'milkode/grep/findgrep_option'
 require 'optparse'
 require 'tempfile'
+require 'open3'
+require 'shellwords'
 
 module Milkode
   class CLI_Grep
@@ -250,15 +252,15 @@ EOF
         tmpfile.write(files.join("\n"))
         tmpfile.close
         tmpfile.open
-        cmd << "cat #{tmpfile.path}"
+        cmd << ["cat", tmpfile.path]
 
-        cmd << "xargs #{first_command} #{arguments[0]}"
+        cmd << ["xargs", Shellwords.split(first_command), arguments[0]].flatten
 
         (1...arguments.size).each do |index|
-          cmd << "#{second_command} #{arguments[index]}"
+          cmd << [Shellwords.split(second_command), arguments[index]].flatten
         end
 
-        system(cmd.join(" | "))
+        Open3.pipeline(*cmd)
 
         tmpfile.close(true)
       end


### PR DESCRIPTION
gmilk で、「".freeze」という " がマッチしていない文字列を検索したところ、「sh: 1: Syntax error: Unterminated quoted string」というエラーになってしまいました。

```
% gmilk '".freeze'
Because number of records is large, Milkode use external tool. (Same as 'gmilk -e grep')
sh: 1: Syntax error: Unterminated quoted string
```

少し試したところ、以下のようにして再現させることができました。

```
% cd /tmp
% mkdir a
% cd a
% export MILKODE_DEFAULT_DIR=/tmp/a/m      
% milk init
create     : /tmp/a/m/milkode.yaml
create     : /tmp/a/m/db/milkode.db created.
% mkdir z
% echo '"foo".freeze' > z/foo.rb
% milk add z
package    : z
result     : 1 packages, 1 records, 1 add. (0.01sec)
*milkode*  : 1 packages, 1 records in /tmp/a/m/db/milkode.db.
% gmilk -a -e grep '".freeze'
sh: 1: Syntax error: Unterminated quoted string
% milk --version
milk 1.8.4
```

lib/milkode/grep/cli_grep.rb を見るとシェルのメタキャラクタをあまり考慮していない感じで、
まぁシェルを使わないで動かすほうがよかろうということで
Open3.pipeline と Shellwords.split を使うように変えてみました。
(Shellwords.split は "grep -n" などといったものをワード分割するためです。)
いかがでしょうか。

なお、Open3.pipeline が存在する（そして fork を使わなくなって Unix 以外でも動くようになった）のは
Ruby 1.9.2 からなので、
もっと古い Ruby でも動かす必要があるならこの変更はよろしくないと思います。
