### PR TITLE
add the parameter of 'tab_width' for coderay

### DIFF
--- a/lib/milkode/cdweb/lib/coderay_wrapper.rb
+++ b/lib/milkode/cdweb/lib/coderay_wrapper.rb
@@ -52,6 +52,9 @@ module Milkode
     end
 
     def to_html
+      setting = WebSetting.new
+      layout_setting = setting.layout_setting
+
       CodeRay.scan(@content, file_type).
         html2(
               :wrap => nil,
@@ -62,11 +65,15 @@ module Milkode
               :line_number_anchors => false,
               :onclick_copy_line_number => true,
               :onclick_copy_prefix => "/#{@filename}:",
-              :keywords => @keywords
+              :keywords => @keywords,
+              :tab_width => layout_setting[:tab_width],
               )
     end
 
     def to_html_anchorlink(url)
+      setting = WebSetting.new
+      layout_setting = setting.layout_setting
+
       CodeRay.scan(@content, file_type).
         html2(
               :wrap => nil,
@@ -76,7 +83,8 @@ module Milkode
               :line_number_start => @line_number_start,
               :line_number_anchors => 'n',
               :line_number_anchor_url => url,
-              :keywords => @keywords
+              :keywords => @keywords,
+              :tab_width => layout_setting[:tab_width],
               )
     end
 

--- a/lib/milkode/cdweb/lib/web_setting.rb
+++ b/lib/milkode/cdweb/lib/web_setting.rb
@@ -25,6 +25,10 @@ module Milkode
       :hide_update_button => false,
 
       :eliminate_extname => "",
+
+      :layout_setting => {
+        :tab_width => 8
+      }
     }
 
     def self.hash_method(name)
@@ -67,6 +71,8 @@ module Milkode
 
     hash_method :hide_update_button
     hash_method :eliminate_extname
+
+    hash_method :layout_setting
   end
 end
 


### PR DESCRIPTION
## 概要
タブの幅を設定ファイルで指定できるようにしました。

milkweb.yamlの例
```yaml
---
:layout_setting:
 :tab_width: 8
```

## 質問
実装方針がわからないので２点困ってることがあります。必要があれば修正しますのでコメントをもらえればと思います。
* milkweb.yamlへのアクセス方法
milkweb.yamlのオブジェクトに文字列ではなくシンボルでアクセスしたかったのでyamlの書き方が普段みない形になってしまいました。キーワードをコロンで囲む形式です。どうでしょうか？

* 設定ファイルのネストが少し深い
coderayに渡せるパラメータが増えたときを考慮して見た目を設定できる項目を並べられるように１つネストを深い構造になっています。
実装後に気づいたのですがcoderay側にはあまり見た目を変更できる項目がないのでlayout_settingを失くしてしまっても問題ないと思っています。