### PR TITLE
Exit with 1 on error

### DIFF
--- a/lib/milkode/cli.rb
+++ b/lib/milkode/cli.rb
@@ -8,6 +8,10 @@ require 'milkode/grep/cli_grep'
 
 module Milkode
   class CLI < Thor
+    def self.exit_on_failure?
+      true
+    end
+
     class_option :help,    :type => :boolean, :aliases => '-h', :desc => 'Help message.'
     class_option :version, :type => :boolean, :desc => 'Show version.'
 


### PR DESCRIPTION
今日は。

存在しないサブコマンドを実行した時など、エラー時に終了ステータス`1`で終了するパッチを書きました。

    $ milk non-existing-command
    Could not find command "non-existing-command".
    $ echo $?
    1

現在の環境で、`milk remove`がobsoleteかどうかを、「`milk rm`を実行してエラーにならなければ`milk remove`はobsoleteだ」というふうにして判断しようとしたところ、`milk rm`が存在しない古いバージョンでも、エラーにならない（終了ステータスが、Linuxの場合で`0`）ため、この方法を断念した、という経験からです（ https://github.com/kou/gem-milkode/pull/1 ）。
一般に、存在しないサブコマンドを実行した場合の終了ステータスは`0`以外が期待されると思います。

ただ、当然ながらこのパッチは後方互換性を壊します。

    $ milk typo && ...

というような実行の仕方をしている人（シェルスクリプトなど）がうまく動かなくなります。
もしこのパッチを受け入れてもらえる場合も、移行期間を設けたほうがいいかも知れません。

ご検討いただけますでしょうか。
よろしくお願いします。