### PR TITLE
Fix LoadError of coderay/scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ rvm:
   - 1.9.3
   - 2.0.0
 
+sudo: required
 before_install:
   - curl --silent --location https://github.com/groonga/groonga/raw/master/data/travis/setup.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ rvm:
 sudo: required
 before_install:
   - curl --silent --location https://github.com/groonga/groonga/raw/master/data/travis/setup.sh | sh
+  - gem update bundler

--- a/lib/milkode/cdweb/lib/coderay_php_utf8.rb
+++ b/lib/milkode/cdweb/lib/coderay_php_utf8.rb
@@ -6,7 +6,13 @@
 # @date   2012/03/18
 
 require 'rubygems'
-require 'coderay/scanner'
+
+begin
+  # Renamed since CodeRay v1.1.1
+  require 'coderay/scanners'
+rescue LoadError
+  require 'coderay/scanner'
+end
 
 # coderay-1.0.5/lib/coderay/scanners/php.rb
 module CodeRay


### PR DESCRIPTION
`milk web` で coderay/scanner の LoadError が起こる問題を修正しました。

CodeRay v1.1.1 以降では、CodeRay::Scanners モジュールは coderay/scanners.rb に含まれているようです。CodeRay が古かった場合に備え、coderay/scanners.rb が読み込めなかった場合には従来通り coderay/scanner.rb を読み込むようにしました。

参考：https://github.com/rubychan/coderay/commit/b09e97b08c3c073e79159ff09f6a7e0779fcfd2e