### PR TITLE
[WIP]Select query strings on search box when focused, and scroll to top when keyboard shortcut s pressed

### DIFF
--- a/lib/milkode/cdweb/views/milkode.js
+++ b/lib/milkode/cdweb/views/milkode.js
@@ -244,6 +244,7 @@ $(document).ready(function() {
     if (!isFocused && k == 115) {
       $("#query").focus();
       e.preventDefault();
+      $("html,body").animate({ scrollTop: 0 }, "fast");
     }
 
     // S .. Search using a selected text (New tab)

--- a/lib/milkode/cdweb/views/milkode.js
+++ b/lib/milkode/cdweb/views/milkode.js
@@ -205,6 +205,10 @@ $(document).ready(function() {
   //   $(this).select();
   // });
 
+  $('#query').focus(function(){
+    $(this).select();
+  });
+
   $('#shead').change(function(){
     $('#search').click();
   });


### PR DESCRIPTION
web インターフェースに次の修正を入れてみました。

- 検索ボックスにフォーカスが移ると、検索ボックスのキーワードをすべて選択状態にする
- ショートカットキーの `s` が押されると、ページトップにスクロールする

#40 で @ongaeshi さんがコメントされているように、キーワードを継ぎ足すよりも差し替えることの方が多いと思います。これらの修正によって、より検索しやすくなると思います。