### PR TITLE
Fix error when new search during relative url mode

### DIFF
--- a/lib/milkode/cdweb/views/index.haml
+++ b/lib/milkode/cdweb/views/index.haml
@@ -28,6 +28,7 @@
               %input#query(name="query" type="text" style="width: 419px;")
               %input(type="submit" value="#{t(:search)}")
               %input(name='pathname' type='hidden' value='#{url_for '/home'}')
+              %input(name='relative_url' type='hidden' value='#{ENV['MILKODE_RELATIVE_URL']}')
               &nbsp;&nbsp;<a href="#{url_for '/help'}">#{t(:help)}</a>
 
       .row

--- a/lib/milkode/cdweb/views/milkode.js
+++ b/lib/milkode/cdweb/views/milkode.js
@@ -17,6 +17,13 @@ function divideURL(url) {
 
   var path = found[4];
 
+  // when using relative url mode
+  var relative_url = $(":hidden[name='relative_url']").val();
+  if (relative_url !== undefined) {
+    head += relative_url;
+    path = path.replace(new RegExp("^" + relative_url), "");
+  }
+
   return [head, path];
 }
 

--- a/lib/milkode/cdweb/views/search_form.haml
+++ b/lib/milkode/cdweb/views/search_form.haml
@@ -19,3 +19,4 @@
       = create_favorite_list(@package_list)
       
       %input(name="pathname" type="hidden" value="")
+      %input(name="relative_url" type="hidden" value="#{ENV['MILKODE_RELATIVE_URL']}")


### PR DESCRIPTION
相対URLモードで起動していると、ショートカットキー `S` による新タブ検索が行えない問題を修正しました。