### PR TITLE
Fix dividing an IP-addressed URL

### DIFF
--- a/lib/milkode/cdweb/views/milkode.js
+++ b/lib/milkode/cdweb/views/milkode.js
@@ -8,11 +8,11 @@ function escapeHTML(str) {
 }
 
 function divideURL(url) {
-  var found = url.match(/^(.+?):\/\/([A-Za-z\d\-.]+?):?(\d+)?(\/.*)?$/);
+  var found = url.match(/^(.+?):\/\/([A-Za-z\d\-.]+?)(:\d+)?(\/.*)?$/);
 
   var head = found[1] + "://" + found[2];
   if (found[3]) {
-    head += ":" + found[3];
+    head += found[3];
   }
 
   var path = found[4];


### PR DESCRIPTION
If the host of the current URL is a raw IP address and no port number exists
(e.g. http://127.0.0.1/), the Milkode Web application fails to search by using
the keyboard shortcut `S`, because it misinterprets the last octet as a port
number.